### PR TITLE
feat: create UserRepository and minor update in User entity

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/User.java
+++ b/backend/src/main/java/com/mymemo/backend/User.java
@@ -11,14 +11,19 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
     private String nickname;
 
-    private String email;
+    @Column(nullable = false, unique = true)
+    private String email;   // 이메일은 로그인 및 식별의 기준이 되므로 고유해야 함
 
+    @Column(nullable = false)
     private LocalDate birthDate;
 
+    @Column(nullable = false)
     private LocalDate createdAt;
 
     protected User() {}
@@ -47,6 +52,7 @@ public class User {
 
     public void changeBirthDate(LocalDate birthDate) {
         if (birthDate == null) {
+            // 생일은 회원가입 이후 변경 가능하지만, null로 바꾸는 것은 금지
             throw new IllegalArgumentException("생년월일은 null일 수 없습니다.");
         }
         this.birthDate = birthDate;

--- a/backend/src/main/java/com/mymemo/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.mymemo.backend.repository;
+
+import com.mymemo.backend.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+
+}


### PR DESCRIPTION
- Created `UserRepository` interface
    - Extends `JpaRepository<User, Long>`
    - Added method `findByEmail` to look up a user by email address
    - Added method `existsByEmail` to check for email duplication

- Updated `User` entity
    - Minor adjustments for JPA integration (e.g., `@Column(nullable = false)`, `unique = true`)