### PR TITLE
Refactor Memo entity: apply MemoCategory enum and set default pinOrder

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -1,9 +1,9 @@
 package com.mymemo.backend.entity;
 
+import com.mymemo.backend.entity.enums.MemoCategory;
 import com.mymemo.backend.entity.enums.Visibility;
 import jakarta.persistence.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -35,11 +35,12 @@ public class Memo {
     @Column(nullable = false, length = 10)
     private Visibility visibility;
 
-    @Column(nullable = false, length=50)
-    private String category;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private MemoCategory memoCategory;
 
     @Column(nullable = false)
-    private int pinOrder;   // 상단 고정 순서, 기본 0
+    private int pinOrder = 0;   // 상단 고정 순서, 기본 0
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/mymemo/backend/entity/enums/MemoCategory.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/enums/MemoCategory.java
@@ -1,0 +1,11 @@
+package com.mymemo.backend.entity.enums;
+
+public enum MemoCategory {
+    WORK,
+    HOBBY,
+    PERSONAL,
+    URGENT,
+    STUDY,
+    IDEA,
+    ETC     // 기본값
+}


### PR DESCRIPTION
## Summary
- Replaced String category field with MemoCategory enum to enforce fixed categories (e.g., WORK, HOBBY, STUDY, etc.)
- Applied @Enumerated(EnumType.STRING) with length = 10 for clarity and DB integrity
- Set default value of pinOrder to 0 for stable ordering
- Visibility enum field retained; default behavior set to PRIVATE (UI-hidden)

## Motivation
- Prevent inconsistency from free-text category inputs
- Prepare for future features such as category-based filtering
- Improve entity structure clarity and default value handling

## Note
- MemoCategory enum includes: WORK, HOBBY, PERSONAL, URGENT, STUDY, IDEA, ETC