### PR TITLE
feat: add constructors to Memo entity and comment to User entity

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -2,6 +2,7 @@ package com.mymemo.backend.entity;
 
 import com.mymemo.backend.entity.enums.MemoCategory;
 import com.mymemo.backend.entity.enums.Visibility;
+import com.mymemo.backend.global.exception.CustomException;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -40,7 +41,7 @@ public class Memo {
     private MemoCategory memoCategory;
 
     @Column(nullable = false)
-    private int pinOrder = 0;   // 상단 고정 순서, 기본 0
+    private int pinOrder;   // 상단 고정 순서, 기본 0
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -48,10 +49,41 @@ public class Memo {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    protected Memo() {}     // protected를 하여 불필요한 객체 생성 가능성 방지
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = this.createdAt;
+    }
+
+    public Memo(User user, String title, String content, MemoCategory memoCategory) {
+        if (user == null) {
+            throw new CustomException("작성자는 필수입니다.", 400);
+        }
+        this.user = user;
+
+        if ((title == null || title.isBlank()) && (content == null || content.isBlank())) {
+            throw new CustomException("아무 것도 작성하지 않으셨습니다.", 400);
+        }
+
+        if (title == null || title.isBlank()) {
+            this.title = "untitled";
+        } else {
+            this.title = title;
+        }
+        this.content = content;
+
+        if (memoCategory == null) {
+            this.memoCategory = MemoCategory.ETC;
+        } else {
+            this.memoCategory = memoCategory;
+        }
+
+        this.isPinned = false;
+        this.isDeleted = false;
+        this.visibility = Visibility.PUBLIC;
+        this.pinOrder = 0;
     }
 
     @PreUpdate

--- a/backend/src/main/java/com/mymemo/backend/entity/User.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/User.java
@@ -27,7 +27,7 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    protected User() {}
+    protected User() {}     // protected를 하여 JPA는 호출 가능, 외부 코드에서는 직접 호출 제한됨 (불필요한 객체 생성 가능성 방지)
 
     @PrePersist
     protected void onCreate() {


### PR DESCRIPTION
## Summary
- Added comments explaining the use of the 'protected' access modifier in the default constructors of `User` and `Memo` entities
- Added a default constructor to `Memo` entity
- Added a fully parameterized constructor to the `Memo` entity, including validation and default value handling

## Motivation
- A fully parameterized constructor in the `Memo` entity was needed to support the implementation of `MemoService`

## Changed Classes
- Memo
- User