### PR TITLE
feat: add ErrorCode and apply it to CustomException handling

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.mymemo.backend.auth.service;
 import com.mymemo.backend.auth.dto.SignupRequestDto;
 import com.mymemo.backend.entity.User;
 import com.mymemo.backend.global.exception.CustomException;
+import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,12 +19,12 @@ public class AuthService {
     public void signup(SignupRequestDto dto) {
         // 1. 이메일 중복 체크
         if (userRepository.existsByEmail(dto.getEmail())) {
-            throw new CustomException("이미 사용 중인 이메일입니다.", 400);
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
         // 2. 비밀번호 확인 일치 여부
         if (!dto.getPassword().equals(dto.getPasswordCheck())) {
-            throw new CustomException("비밀번호와 비밀번호 확인이 일치하지 않습니다.", 400);
+            throw new CustomException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 
         // 비밀번호 암호화

--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -3,6 +3,7 @@ package com.mymemo.backend.entity;
 import com.mymemo.backend.entity.enums.MemoCategory;
 import com.mymemo.backend.entity.enums.Visibility;
 import com.mymemo.backend.global.exception.CustomException;
+import com.mymemo.backend.global.exception.ErrorCode;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -59,12 +60,12 @@ public class Memo {
 
     public Memo(User user, String title, String content, MemoCategory memoCategory) {
         if (user == null) {
-            throw new CustomException("작성자는 필수입니다.", 400);
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
         this.user = user;
 
         if ((title == null || title.isBlank()) && (content == null || content.isBlank())) {
-            throw new CustomException("아무 것도 작성하지 않으셨습니다.", 400);
+            throw new CustomException(ErrorCode.EMPTY_MEMO);
         }
 
         if (title == null || title.isBlank()) {

--- a/backend/src/main/java/com/mymemo/backend/entity/User.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/User.java
@@ -1,5 +1,7 @@
 package com.mymemo.backend.entity;
 
+import com.mymemo.backend.global.exception.CustomException;
+import com.mymemo.backend.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -43,14 +45,14 @@ public class User {
 
     public void changePassword(String password) {
         if (password == null || password.isBlank()) {
-            throw new IllegalArgumentException("비밀번호는 비어있을 수 없습니다.");
+            throw new CustomException(ErrorCode.MISSING_PASSWORD);
         }
         this.password = password;
     }
 
     public void changeNickname(String nickname) {
         if (nickname == null || nickname.isBlank()) {
-            throw new IllegalArgumentException("닉네임은 비어있을 수 없습니다.");
+            throw new CustomException(ErrorCode.MISSING_NICKNAME);
         }
         this.nickname = nickname;
     }
@@ -58,7 +60,7 @@ public class User {
     public void changeBirthDate(LocalDate birthDate) {
         if (birthDate == null) {
             // 생일은 회원가입 이후 변경 가능하지만, null로 바꾸는 것은 금지
-            throw new IllegalArgumentException("생년월일은 null일 수 없습니다.");
+            throw new CustomException(ErrorCode.MISSING_BIRTHDATE);
         }
         this.birthDate = birthDate;
     }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/CustomException.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/CustomException.java
@@ -1,14 +1,18 @@
 package com.mymemo.backend.global.exception;
 
 public class CustomException extends RuntimeException {
-    private final int status;
+    private final ErrorCode errorCode;
 
-    public CustomException(String message, int status) {
-        super(message);
-        this.status = status;
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
     }
 
     public int getStatus() {
-        return status;
+        return errorCode.getStatus().value();
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.mymemo.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    MISSING_PASSWORD("비밀번호를 입력해주세요 .", HttpStatus.BAD_REQUEST),
+    MISSING_NICKNAME("닉네임을 입력해주세요.", HttpStatus.BAD_REQUEST),
+    MISSING_BIRTHDATE("생년월일을 입력해주세요.", HttpStatus.BAD_REQUEST),
+    EMAIL_ALREADY_EXISTS("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
+    PASSWORD_CONFIRM_MISMATCH("비밀번호와 비밀번호 확인이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_NOT_FOUND("존재하지 않는 이메일 주소입니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CREDENTIALS("이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED_ACCESS("작성자는 필수입니다.", HttpStatus.UNAUTHORIZED),
+    EMPTY_MEMO("아무 것도 작성하지 않으셨습니다.", HttpStatus.BAD_REQUEST),
+    // 필요한 항목 계속 추가 가능
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    ErrorCode(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}


### PR DESCRIPTION
## Summary
- Introduced the `ErrorCode` enum to centralize error message and status code management.
- Modified `CustomException` to use `ErrorCode` for standardized error handling.
- Refactored existing classes to adopt the new `CustomException` structure.

## Motivation
- Writing error messages manually in every exception is repetitive and error-prone.
- Centralizing error definitions improves consistency and maintainability.

## Added Classes
- `ErrorCode` (enum)

## Modified Classes
- `CustomException`
- `User`
- `Memo`
- `AuthController`
- `AuthService`