### PR TITLE
feat: implement memo create API with JWT auth, service, controller, and repository layer

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/filter/JwtAuthenticationFilter.java
@@ -5,14 +5,18 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collections;
 
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
@@ -28,20 +32,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
                                     throws ServletException, IOException {
 
+        log.debug("JwtAuthenticationFilter - 요청 감지됨");
+
         String authHeader = request.getHeader("Authorization");     // Authorization 헤더 추출
+        log.debug("Authorization 헤더: {}", authHeader);
 
         if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);     // "Bearer " 이후 토큰만 추출
             if (jwtUtil.isTokenValid(token)) {      // 토큰 유효성 검사
                 String email = jwtUtil.getEmailFromToken(token);    // 이메일(subject) 추출
 
-                // 인증 객체 생성 (권한 정보는 현재 null)
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(email, null, null);
+                log.info("유효한 JWT, 사용자 이메일: {}", email);
 
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));      // 요청 정보 세부 설정 (IP, 세션 등 포함됨)
+                // 인증 객체 생성 (권한 정보는 현재 null)
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                email,
+                                null,
+                                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );      // 요청 정보 세부 설정 (IP, 세션 등 포함됨)
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);   // 현재 요청의 SecurityContext에 인증 정보 저장
+
+                log.debug("SecurityContext에 인증 정보 등록 완료");
+            } else {
+                log.warn("JWT 유효성 검사 실패");
             }
+        } else {
+            log.debug("Authorization 헤더 없음 또는 Bearer 형식 불일치: {}", authHeader);
         }
 
         filterChain.doFilter(request, response);    // 다음 필터로 요청 전달 (필수)

--- a/backend/src/main/java/com/mymemo/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/mymemo/backend/config/OpenApiConfig.java
@@ -2,6 +2,11 @@ package com.mymemo.backend.config;
 
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration      // @Configuration으로 등록돼 있기 때문에 프로젝트가 실행되면서 springdoc-openapi가 자동으로 인식한다.
@@ -12,4 +17,18 @@ import org.springframework.context.annotation.Configuration;
         bearerFormat = "JWT"                // 포맷이 JWT임을 Swagger에 설명
 )
 public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("MyMemo API").version("1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("Authorization"))
+                .components(new Components()
+                        .addSecuritySchemes("Authorization",
+                                new io.swagger.v3.oas.models.security.SecurityScheme()
+                                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        ));
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
@@ -28,6 +28,12 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    // JwtAuthenticationFilter는 공통이므로 따로 @Bean 등록
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil);
+    }
+
     @Bean
     @Profile("dev")
     public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -44,7 +50,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()   // 그 외는 인증 필요
                 )
                 .formLogin(form -> form.disable())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -38,7 +38,7 @@ public class Memo {
     private Visibility visibility;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(name = "category", nullable = false, length = 10)
     private MemoCategory memoCategory;
 
     @Column(nullable = false)
@@ -58,7 +58,7 @@ public class Memo {
         this.updatedAt = this.createdAt;
     }
 
-    public Memo(User user, String title, String content, MemoCategory memoCategory) {
+    public Memo(User user, String title, String content, MemoCategory memoCategory, Visibility visibility, boolean isPinned, boolean isDeleted, int pinOrder) {
         if (user == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -81,14 +81,20 @@ public class Memo {
             this.memoCategory = memoCategory;
         }
 
-        this.isPinned = false;
-        this.isDeleted = false;
-        this.visibility = Visibility.PUBLIC;
-        this.pinOrder = 0;
+        if (visibility == null) {
+            this.visibility = Visibility.PUBLIC;
+        } else {
+            this.visibility = visibility;
+        }
+
+        this.isPinned = isPinned;
+        this.isDeleted = isDeleted;
+        this.pinOrder = pinOrder;
     }
 
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
 }

--- a/backend/src/main/java/com/mymemo/backend/global/util/SecurityUtil.java
+++ b/backend/src/main/java/com/mymemo/backend/global/util/SecurityUtil.java
@@ -1,0 +1,21 @@
+package com.mymemo.backend.global.util;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * 인증 정보에서 현재 로그인한 사용자의 이메일(username)을 반환하는 유틸 클래스.
+ *
+ * Spring Security의 Authentication 객체에서 getName()을 호출하여 username을 가져오며,
+ * 일반적으로 이 username은 사용자의 이메일 주소이다.
+ */
+public class SecurityUtil {
+
+    /**
+     * 현재 SecurityContext에 저장된 인증 정보에서 사용자 이메일을 반환한다.
+     *
+     * @return 로그인한 사용자의 이메일 (Authentication.getName())
+     */
+    public static String getCurrentUserEmail() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+}

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,0 +1,30 @@
+package com.mymemo.backend.memo.controller;
+
+import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
+import com.mymemo.backend.memo.service.MemoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/memos")
+@RequiredArgsConstructor
+public class MemoController {
+
+    private final MemoService memoService;
+
+    /**
+     * 메모 생성 API
+     * @param requestDto 제목, 카테고리, 내용
+     * @return 메모 생성 성공 메시지
+     */
+    @PostMapping
+    public ResponseEntity<?> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
+        memoService.createMemo(requestDto);     // 메모 생성 로직 위임
+        return ResponseEntity.ok("메모 생성 성공");
+    }
+
+}

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
@@ -1,20 +1,29 @@
 package com.mymemo.backend.memo.dto;
 
+import com.mymemo.backend.entity.Memo;
+import com.mymemo.backend.entity.User;
 import com.mymemo.backend.entity.enums.MemoCategory;
+import com.mymemo.backend.entity.enums.Visibility;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public class MemoCreateRequestDto {
 
+    @Schema(description = "메모 제목")
     private String title;
+
+    @Schema(description = "메모 내용")
     private String content;
+
+    @Schema(description = "메모 카테고리")
     private MemoCategory memoCategory;
 
-    public MemoCreateRequestDto() {}    // @RequestBody 바인딩 시 Jackson이 사용 (필수)
+    @Schema(description = "공개 여부", defaultValue = "PUBLIC")
+    private Visibility visibility;
 
-    public MemoCreateRequestDto(String title, String content, MemoCategory memoCategory) {      // 테스트나 명시적 객체 생성 시 편의용
-        this.title = title;
-        this.content = content;
-        this.memoCategory = memoCategory;
-    }
+    @Schema(description = "상단 고정 여부", defaultValue = "false")
+    private boolean isPinned;
+
+    public MemoCreateRequestDto() {}    // @RequestBody 바인딩 시 Jackson이 사용 (필수)
 
     // Getter 메서드들
     public String getTitle() {
@@ -27,5 +36,36 @@ public class MemoCreateRequestDto {
 
     public MemoCategory getMemoCategory() {
         return memoCategory;
+    }
+
+    public Visibility getVisibility() { return visibility; }
+
+    public boolean isPinned() { return isPinned; }
+
+    // Setter 메서드들 (JSON -> DTO 매핑을 위해 필수)
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setMemoCategory(MemoCategory memoCategory) {
+        this.memoCategory = memoCategory;
+    }
+
+    public void setVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
+    public void setPinned(boolean pinned) {
+        this.isPinned = pinned;
+    }
+
+    // 엔터티 생성 메서드. DTO -> Entity 변환 책임 (중심 로직)
+    public Memo toEntity(User user) {
+
+        return new Memo(user, title, content, memoCategory, visibility, isPinned, false, 0);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoResponseDto.java
@@ -1,0 +1,18 @@
+package com.mymemo.backend.memo.dto;
+
+import com.mymemo.backend.entity.enums.MemoCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter     // 모든 필드에 대해 getter 메서드를 자동 생성하는 Lombok 어노테이션
+@AllArgsConstructor     // 모든 필드를 매개변수로 받는 생성자를 자동으로 생성한다. DTO를 사용할 때 생성자를 통해 값을 한 번에 주입할 수 있어 코드가 간결해진다.
+public class MemoResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private MemoCategory memoCategory;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -1,0 +1,31 @@
+package com.mymemo.backend.memo.service;
+
+import com.mymemo.backend.entity.User;
+import com.mymemo.backend.global.exception.CustomException;
+import com.mymemo.backend.global.exception.ErrorCode;
+import com.mymemo.backend.global.util.SecurityUtil;
+import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
+import com.mymemo.backend.repository.MemoRepository;
+import com.mymemo.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final UserRepository userRepository;
+    private final MemoRepository memoRepository;
+
+    @Transactional
+    public void createMemo(MemoCreateRequestDto dto) {
+
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_FOUND));
+
+        memoRepository.save(dto.toEntity(user));
+    }
+}

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -1,0 +1,18 @@
+package com.mymemo.backend.repository;
+
+import com.mymemo.backend.entity.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+
+    /**
+     * 이 인터페이스를 선언하는 것만으로도 Spring Data JPA는 다음과 같은 메서드를 자동으로 제공한다.
+     *
+     * save(Memo memo)      메모 저장 (INSERT or UPDATE)
+     * findById(Long id)    메모 단건 조회
+     * findAll()            전체 메모 목록 조회
+     * deleteById(Long id)  메모 삭제
+     * count()              메모 개수 조회
+     * existsById(Long id)  메모 존재 여부 확인
+     */
+}


### PR DESCRIPTION
### Summary
- Added Memo creation flow including Controller, Service, DTO, and Repository.
- Integrated JWT authentication to identify the currently logged-in user via SecurityContext.
- Applied Slf4j logging to JwtAuthenticationFilter and JwtUtil.
- Configured Swagger for Bearer token-based authorization.

### Changes
- Added: MemoController, MemoService, MemoCreateRequestDto, MemoResponseDto, MemoRepository
- Modified: Memo entity constructor to support full initialization via DTO
- Added: SecurityUtil to extract email from SecurityContext
- Enhanced: JwtAuthenticationFilter and JwtUtil with Slf4j-based structured logging

### Motivation
This feature allows authenticated users to create memos. It ensures only valid JWT tokens can access protected memo-related endpoints.