### PR TITLE
fix: resolve Swagger default value issue for pinned field in MemoCreateRequestDto

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.mymemo.backend.memo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.User;
 import com.mymemo.backend.entity.enums.MemoCategory;
@@ -20,8 +21,9 @@ public class MemoCreateRequestDto {
     @Schema(description = "공개 여부", defaultValue = "PUBLIC")
     private Visibility visibility;
 
-    @Schema(description = "상단 고정 여부", defaultValue = "false")
-    private boolean isPinned;
+    @Schema(description = "상단 고정 여부", defaultValue = "false", example = "false")
+    @JsonProperty("pinned")
+    private boolean isPinned = false;
 
     public MemoCreateRequestDto() {}    // @RequestBody 바인딩 시 Jackson이 사용 (필수)
 


### PR DESCRIPTION
### Summary
This PR fixes an issue where the Swagger UI incorrectly displayed the `pinned` field as `true` by default, despite the actual default being `false`.

### Changes
- Annotated `isPinned` with `@JsonProperty("pinned")` to ensure correct serialization
- Set default value to `false` both in `@Schema` and field initializer
- Verified that the Swagger example value now correctly shows `"pinned": false`

### Motivation
Improves developer experience by ensuring that Swagger-generated example values accurately reflect the backend behavior, preventing confusion during API testing.