### PR TITLE
feat: apply MemoResponseDto rather than just returning message

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -5,9 +5,11 @@ import com.mymemo.backend.entity.enums.Visibility;
 import com.mymemo.backend.global.exception.CustomException;
 import com.mymemo.backend.global.exception.ErrorCode;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Entity
 @Table(name = "memo")
 public class Memo {

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,6 +1,7 @@
 package com.mymemo.backend.memo.controller;
 
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
+import com.mymemo.backend.memo.dto.MemoResponseDto;
 import com.mymemo.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +23,9 @@ public class MemoController {
      * @return 메모 생성 성공 메시지
      */
     @PostMapping
-    public ResponseEntity<?> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
-        memoService.createMemo(requestDto);     // 메모 생성 로직 위임
-        return ResponseEntity.ok("메모 생성 성공");
+    public ResponseEntity<MemoResponseDto> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
+        MemoResponseDto responseDto = memoService.createMemo(requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoResponseDto.java
@@ -1,5 +1,6 @@
 package com.mymemo.backend.memo.dto;
 
+import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.enums.MemoCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,7 +8,6 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter     // 모든 필드에 대해 getter 메서드를 자동 생성하는 Lombok 어노테이션
-@AllArgsConstructor     // 모든 필드를 매개변수로 받는 생성자를 자동으로 생성한다. DTO를 사용할 때 생성자를 통해 값을 한 번에 주입할 수 있어 코드가 간결해진다.
 public class MemoResponseDto {
 
     private Long id;
@@ -15,4 +15,12 @@ public class MemoResponseDto {
     private String content;
     private MemoCategory memoCategory;
     private LocalDateTime createdAt;
+
+    public MemoResponseDto(Memo memo) {
+        this.id = memo.getId();
+        this.title = memo.getTitle();
+        this.content = memo.getContent();
+        this.memoCategory = memo.getMemoCategory();
+        this.createdAt = memo.getCreatedAt();
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -1,10 +1,12 @@
 package com.mymemo.backend.memo.service;
 
+import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.User;
 import com.mymemo.backend.global.exception.CustomException;
 import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
+import com.mymemo.backend.memo.dto.MemoResponseDto;
 import com.mymemo.backend.repository.MemoRepository;
 import com.mymemo.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +21,14 @@ public class MemoService {
     private final MemoRepository memoRepository;
 
     @Transactional
-    public void createMemo(MemoCreateRequestDto dto) {
+    public MemoResponseDto createMemo(MemoCreateRequestDto dto) {
 
         String email = SecurityUtil.getCurrentUserEmail();
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_FOUND));
 
-        // 기존: Memo 생성자 직접 호출
-        // 수정: DTO의 toEntity(user) 활용으로 책임 위임 및 간결화
-        memoRepository.save(dto.toEntity(user));
+        Memo memo = memoRepository.save(dto.toEntity(user));
+        return new MemoResponseDto(memo);
     }
 }


### PR DESCRIPTION
## Summary
- Applied MemoResponeDto to return the memo entity I created rather than just returning the message "메모 생성 성공".

## Motivation
- Improve API clarity and usability by providing meaningful response data after memo creation.
- Align return type with standard RESTful practices (i.e. return the created resource).

## Modified Classes
- `Memo` : Added @Getter annotation.
- `MemoResponseDto` : Removed @AllArgsConstructor and added constructor manually.
- `MemoService` : Linked MemoResponseDto.
- `MemoController` : Replaced string message return to MemoResponseDto.