### PR TITLE
feat: add custom mapping logic in MemoCategory enum to cover ETC as default

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/enums/MemoCategory.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/enums/MemoCategory.java
@@ -1,5 +1,7 @@
 package com.mymemo.backend.entity.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum MemoCategory {
     WORK,
     HOBBY,
@@ -7,5 +9,17 @@ public enum MemoCategory {
     URGENT,
     STUDY,
     IDEA,
-    ETC     // 기본값
+    ETC;     // 기본값
+
+    @JsonCreator
+    public static MemoCategory from(String value) {
+        if (value == null || value.isBlank()) {
+            return ETC;
+        }
+        try {
+            return MemoCategory.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ETC;
+        }
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
@@ -15,7 +15,10 @@ public class MemoCreateRequestDto {
     @Schema(description = "메모 내용")
     private String content;
 
-    @Schema(description = "메모 카테고리")
+    @Schema(description = "메모 카테고리",
+            allowableValues = {"WORK", "HOBBY", "PERSONAL", "URGENT", "STUDY", "IDEA", "ETC"},
+            defaultValue = "ETC",
+            example = "ETC")
     private MemoCategory memoCategory;
 
     @Schema(description = "공개 여부", defaultValue = "PUBLIC")


### PR DESCRIPTION
## Summary
- Added custom deserialization logic to handle invalid or blank `memoCategory` values by defaulting to `ETC`
- Implemented `@JsonCreator` in the `MemoCategory` enum to ensure safe mapping during JSON deserialization

## Motivation
- Prevents errors when clients send empty or incorrect `memoCategory` values via Swagger or frontend
- Improves user experience by gracefully falling back to a default category (`ETC`) instead of throwing exceptions

## Modified
- `MemoCategory.java`: Added `@JsonCreator` to handle invalid inputs
- Swagger test verified for cases with empty, null, or incorrect category values