### PR TITLE
feat: add MemoListResponseDto with preview field for memo list display and refactored MemoResponseDto to MemoCreateResponseDto for specific use

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,7 +1,7 @@
 package com.mymemo.backend.memo.controller;
 
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
-import com.mymemo.backend.memo.dto.MemoResponseDto;
+import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
 import com.mymemo.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +23,8 @@ public class MemoController {
      * @return 메모 생성 성공 메시지
      */
     @PostMapping
-    public ResponseEntity<MemoResponseDto> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
-        MemoResponseDto responseDto = memoService.createMemo(requestDto);
+    public ResponseEntity<MemoCreateResponseDto> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
+        MemoCreateResponseDto responseDto = memoService.createMemo(requestDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateResponseDto.java
@@ -2,13 +2,12 @@ package com.mymemo.backend.memo.dto;
 
 import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.enums.MemoCategory;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter     // 모든 필드에 대해 getter 메서드를 자동 생성하는 Lombok 어노테이션
-public class MemoResponseDto {
+public class MemoCreateResponseDto {
 
     private Long id;
     private String title;
@@ -16,7 +15,7 @@ public class MemoResponseDto {
     private MemoCategory memoCategory;
     private LocalDateTime createdAt;
 
-    public MemoResponseDto(Memo memo) {
+    public MemoCreateResponseDto(Memo memo) {
         this.id = memo.getId();
         this.title = memo.getTitle();
         this.content = memo.getContent();

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
@@ -1,0 +1,47 @@
+package com.mymemo.backend.memo.dto;
+
+import com.mymemo.backend.entity.Memo;
+import com.mymemo.backend.entity.enums.MemoCategory;
+import com.mymemo.backend.entity.enums.Visibility;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MemoListResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private MemoCategory memoCategory;
+    private Visibility visibility;
+    private boolean isPinned;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String preview;     // 메모 전체 조회할 때 100자까지만 미리보기
+
+    public MemoListResponseDto(Memo memo) {
+        this.id = memo.getId();
+        this.title = memo.getTitle();
+        this.content = memo.getContent();
+        this.memoCategory = memo.getMemoCategory();
+        this.visibility = memo.getVisibility();
+        this.isPinned = memo.isPinned();
+        this.createdAt = memo.getCreatedAt();
+        this.updatedAt = memo.getUpdatedAt();
+        this.preview = generatePreview(content);
+    }
+
+    private String generatePreview(String content) {
+        if (content == null || content.isBlank()) {
+            return "";
+        }
+        String preview;
+        if (content.length() <= 100) {
+            preview = content;
+        } else {
+            preview = content.substring(0, 100) + "...";
+        }
+        return preview;
+    }
+}

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -6,7 +6,7 @@ import com.mymemo.backend.global.exception.CustomException;
 import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
-import com.mymemo.backend.memo.dto.MemoResponseDto;
+import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
 import com.mymemo.backend.repository.MemoRepository;
 import com.mymemo.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class MemoService {
     private final MemoRepository memoRepository;
 
     @Transactional
-    public MemoResponseDto createMemo(MemoCreateRequestDto dto) {
+    public MemoCreateResponseDto createMemo(MemoCreateRequestDto dto) {
 
         String email = SecurityUtil.getCurrentUserEmail();
 
@@ -29,6 +29,8 @@ public class MemoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_FOUND));
 
         Memo memo = memoRepository.save(dto.toEntity(user));
-        return new MemoResponseDto(memo);
+        return new MemoCreateResponseDto(memo);
     }
+
+    public List<Memo>
 }


### PR DESCRIPTION
## Summary
- Added MemoListReponseDto with preview field, showing the content up to count 100.
- Refactored `MemoResponseDto` to `MemoCreateResponseDto` in order to specify the use.

## Motivation
- Needed to specify the name of the dto since the fields I wanted to return were different from creating and retrieving.

## Modified
- `MemoController`
- `MemoCreateResponseDto`
- `MemoService`

## Added
- `MemoListResponseDto`