### PR TITLE
feat: implement memo list retrieval by authenticated user

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     INVALID_CREDENTIALS("이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_ACCESS("작성자는 필수입니다.", HttpStatus.UNAUTHORIZED),
     EMPTY_MEMO("아무 것도 작성하지 않으셨습니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     // 필요한 항목 계속 추가 가능
     ;
 

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,14 +1,16 @@
 package com.mymemo.backend.memo.controller;
 
+import com.mymemo.backend.entity.User;
+import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
 import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
+import com.mymemo.backend.memo.dto.MemoListResponseDto;
 import com.mymemo.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/memos")
@@ -28,4 +30,10 @@ public class MemoController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @GetMapping
+    public ResponseEntity<List<MemoListResponseDto>> getAllMemos() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        List<MemoListResponseDto> response = memoService.getAllMemos(email);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -36,7 +36,10 @@ public class MemoService {
         return new MemoCreateResponseDto(memo);
     }
 
-    public List<MemoListResponseDto> getAllMemos(User user) {
+    public List<MemoListResponseDto> getAllMemos(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         List<Memo> memos = memoRepository.findAllByUserAndIsDeletedFalseOrderByUpdatedAtDesc(user);
         List<MemoListResponseDto> responseList = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- Added memo list retrieval functionality for the authenticated user
- Integrated `SecurityUtil.getCurrentUserEmail()` to identify user via JWT
- Returned results as `List<MemoListResponseDto>`, sorted by `updatedAt` in descending order

## Changes
- `MemoController`: added GET `/api/memos` endpoint
- `MemoService`: implemented `getAllMemos(String email)` method
- `MemoRepository`: added custom query `findAllByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user)`
- `ErrorCode`: added `USER_NOT_FOUND` for user lookup failure

## Motivation
- Enables users to view their memo list after login
- This step lays the foundation for pagination and search filtering features later

