### PR TITLE
feat: implement pagination for memo list API with custom PageResponseDto

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -5,9 +5,15 @@ import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
 import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
 import com.mymemo.backend.memo.dto.MemoListResponseDto;
+import com.mymemo.backend.memo.dto.PageResponseDto;
 import com.mymemo.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,14 +39,15 @@ public class MemoController {
     }
 
     @GetMapping
-    public ResponseEntity<List<MemoListResponseDto>> getAllMemos() {
-        long start = System.currentTimeMillis();
+    public ResponseEntity<PageResponseDto<MemoListResponseDto>> getMemos(
+            @ParameterObject @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+//        long start = System.currentTimeMillis();
 
         String email = SecurityUtil.getCurrentUserEmail();
-        List<MemoListResponseDto> response = memoService.getAllMemos(email);
+        PageResponseDto<MemoListResponseDto> response = memoService.getMemos(email, pageable);
 
-        long end = System.currentTimeMillis();
-        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
+//        long end = System.currentTimeMillis();
+//        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
@@ -44,4 +44,8 @@ public class MemoListResponseDto {
         }
         return preview;
     }
+
+    public static MemoListResponseDto from(Memo memo) {
+        return new MemoListResponseDto(memo);
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/PageResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/PageResponseDto.java
@@ -1,0 +1,17 @@
+package com.mymemo.backend.memo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResponseDto<T> {
+    private List<T> content;        // 실제 응답 리스트
+    private int page;               // 현재 페이지 번호 (0부터 시작)
+    private int size;               // 페이지 당 개수
+    private long totalElements;     // 전체 항목 수
+    private int totalPages;         // 전체 페이지 수
+    private boolean last;           // 마지막 페이지 여부
+}

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -2,6 +2,8 @@ package com.mymemo.backend.repository;
 
 import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -20,6 +22,8 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
      */
 
     List<Memo> findAllByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user);
+
+    Page<Memo> findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user, Pageable pageable);
 
     long countByUser(User user);
 }


### PR DESCRIPTION
## Summary
- Implemented pagination for the memo list API using Spring Data's Pageable.
- Introduced a generic `PageResponseDto<T>` to wrap paginated responses in a consistent format.
- Adjusted controller, service, and repository to support pagination and prevent loading all records at once.

## Motivation
The previous implementation fetched the entire memo list at once, which caused performance degradation and heavy frontend rendering. To address this, pagination was introduced to improve scalability and response time.

## Changes
- `MemoController`: added support for Pageable, returning `PageResponseDto<MemoListResponseDto>`.
- `MemoService`: paginated queries and mapping.
- `MemoRepository`: added `findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(...)`.
- `PageResponseDto`: new generic class to standardize paginated API responses.

## Test
- Verified via Swagger that `?page=0&size=10` correctly returns 10 most recent memos.
- Confirmed total pages, last page flag, and pagination metadata are accurate.