### PR TITLE
feat: Add title keyword search and extract pagination response logic

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -47,7 +47,7 @@ public class MemoController {
     @GetMapping
     public ResponseEntity<PageResponseDto<MemoListResponseDto>> getMemos(
             @ParameterObject @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
-//        long start = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
 
         // 현재 로그인된 사용자의 이메일을 가져옴
         String email = SecurityUtil.getCurrentUserEmail();
@@ -55,8 +55,8 @@ public class MemoController {
         // MemoService를 통해 페이징 처리된 메모 목록 응답을 받음
         PageResponseDto<MemoListResponseDto> response = memoService.getMemos(email, pageable);
 
-//        long end = System.currentTimeMillis();
-//        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
+        long end = System.currentTimeMillis();
+        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -39,6 +39,20 @@ public class MemoService {
         return new MemoCreateResponseDto(memo);
     }
 
+    private PageResponseDto<MemoListResponseDto> toPageResponse(Page<Memo> memoPage) {
+        // 엔티티 -> DTO 매핑
+        Page<MemoListResponseDto> dtoPage = memoPage.map(MemoListResponseDto::from);
+        // 커스텀 Page 응답 DTO에 필요한 정보 구성
+        return new PageResponseDto<>(
+                dtoPage.getContent(),       // 현재 페이지의 데이터 리스트
+                dtoPage.getNumber(),        // 현재 페이지 번호
+                dtoPage.getSize(),          // 페이지당 개수
+                dtoPage.getTotalElements(), // 전체 항목 수
+                dtoPage.getTotalPages(),    // 전체 페이지 수
+                dtoPage.isLast()            // 마지막 페이지 여부
+        );
+    }
+
     /**
      * 페이징 처리된 메모 목록을 조회
      * @param email 현재 로그인한 사용자 이메일
@@ -53,17 +67,22 @@ public class MemoService {
         // 삭제되지 않은 메모들을 최신순으로 페이징 조회
         Page<Memo> memoPage = memoRepository.findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(user, pageable);
 
-        // 엔티티 -> DTO 매핑
-        Page<MemoListResponseDto> dtoPage = memoPage.map(MemoListResponseDto::from);
+        return toPageResponse(memoPage);
+    }
 
-        // 커스텀 Page 응답 DTO에 필요한 정보 구성
-        return new PageResponseDto<>(
-                dtoPage.getContent(),       // 현재 페이지의 데이터 리스트
-                dtoPage.getNumber(),        // 현재 페이지 번호
-                dtoPage.getSize(),          // 페이지당 개수
-                dtoPage.getTotalElements(), // 전체 항목 수
-                dtoPage.getTotalPages(),    // 전체 페이지 수
-                dtoPage.isLast()            // 마지막 페이지 여부
-        );
+    /**
+     * 페이징 처리된, 키워드를 제목에서 검색한 메모 목록 조회
+     * @param email 현재 로그인한 사용자 이메일
+     * @param keyword 검색할 키워드 (제목 기준)
+     * @param pageable 페이징 및 정렬 정보를 포함한 객체
+     * @return PageResponseDto<MemoListResponseDto> 응답 DTO로 감싼 페이징 결과
+     */
+    public PageResponseDto<MemoListResponseDto> getKeywordMemo(String email, String keyword, Pageable pageable) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Page<Memo> memoPage = memoRepository.findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(user, keyword, pageable);
+
+        return toPageResponse(memoPage);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -27,4 +27,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user, Pageable pageable);
 
     long countByUser(User user);
+
+    Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(User user, String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
This PR adds support for searching memos by keyword in the title and refactors pagination response logic for better reuse and clarity.

## Changes
- Added `getKeywordMemo()` method in `MemoService` to handle title-based keyword search
- Extracted duplicated pagination mapping logic into a private `toPageResponse()` method
- Applied `PageResponseDto` consistently to all paginated memo responses

## Motivation
Pagination logic was duplicated across service methods. By extracting it, we reduce redundancy and improve maintainability. Title keyword search is added to enhance user search experience.

## Affected Areas
- `MemoService`
- `MemoRepository` (custom query method added)