### PR TITLE
feat: Add keyword search API for memos with pagination and inactivate faker run

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/init/FakeMemoDataLoader.java
+++ b/backend/src/main/java/com/mymemo/backend/init/FakeMemoDataLoader.java
@@ -33,6 +33,10 @@ public class FakeMemoDataLoader implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
+        boolean enableFaker = false;    // faker 실행할 필요가 있다면 true로 바꾼다.
+        if (!enableFaker) {
+            return;
+        }
         String email = "faker@example.com";
 
         User user = userRepository.findByEmail(email)

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,6 +1,5 @@
 package com.mymemo.backend.memo.controller;
 
-import com.mymemo.backend.entity.User;
 import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
 import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
@@ -10,7 +9,6 @@ import com.mymemo.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -47,7 +45,7 @@ public class MemoController {
     @GetMapping
     public ResponseEntity<PageResponseDto<MemoListResponseDto>> getMemos(
             @ParameterObject @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        long start = System.currentTimeMillis();
+//        long start = System.currentTimeMillis();
 
         // 현재 로그인된 사용자의 이메일을 가져옴
         String email = SecurityUtil.getCurrentUserEmail();
@@ -55,8 +53,32 @@ public class MemoController {
         // MemoService를 통해 페이징 처리된 메모 목록 응답을 받음
         PageResponseDto<MemoListResponseDto> response = memoService.getMemos(email, pageable);
 
-        long end = System.currentTimeMillis();
-        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
+//        long end = System.currentTimeMillis();
+//        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * [GET] /api/memos/search
+     * 제목에 키워드가 포함된 메모들을 페이징 처리하여 조회
+     * @param keyword 검색 키워드 (제목 기준, 대소문자 무시)
+     * @param pageable 페이징 및 정렬 정보
+     * @return 페이징된 메모 응답
+     */
+    @GetMapping("/search")
+    public ResponseEntity<PageResponseDto<MemoListResponseDto>> searchMemosByTitle(
+            @RequestParam String keyword,
+            @ParameterObject @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+//        long start = System.currentTimeMillis();
+
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        PageResponseDto<MemoListResponseDto> response = memoService.getKeywordMemo(email, keyword, pageable);
+
+//        long end = System.currentTimeMillis();
+//        log.info("[searchMemosByTitle] 해당 키워드 포함한 메모 조회 소요 시간: {} ms", (end - start));
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -17,9 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class MemoService {
@@ -39,10 +36,17 @@ public class MemoService {
         return new MemoCreateResponseDto(memo);
     }
 
+    /**
+     * Memo 엔티티 페이지 객체를 MemoListResponseDto로 변환하고,
+     * 커스텀 PageResponseDto로 래핑하여 반환한다.
+     *
+     * @param memoPage Memo 엔티티 페이지 객체
+     * @return 변환된 PageResponseDto<MemoListResponseDto>
+     */
     private PageResponseDto<MemoListResponseDto> toPageResponse(Page<Memo> memoPage) {
-        // 엔티티 -> DTO 매핑
+        // Memo 엔티티 MemoListResponseDto로 매핑
         Page<MemoListResponseDto> dtoPage = memoPage.map(MemoListResponseDto::from);
-        // 커스텀 Page 응답 DTO에 필요한 정보 구성
+        // 커스텀 Page 응답 객체로 변환하여 반환
         return new PageResponseDto<>(
                 dtoPage.getContent(),       // 현재 페이지의 데이터 리스트
                 dtoPage.getNumber(),        // 현재 페이지 번호

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -21,12 +21,21 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
      * existsById(Long id)  메모 존재 여부 확인
      */
 
+    // 해당 사용자의 모든 메모를 최신순으로 조회 (삭제되지 않은 메모만 포함, 페이징 없음) - 현재 사용 X
     List<Memo> findAllByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user);
 
-    // 사용자별 메모 목록을 페이징 + 최신순 정렬로 조회 (삭제되지 않은 메모만 포함)
+    // 해당 사용자의 메모를 페이징 처리하여 최신순으로 조회 (삭제되지 않은 메모만 포함)
     Page<Memo> findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user, Pageable pageable);
 
+    // 해당 사용자가 작성한 전체 메모 개수를 반환 (삭제 여부와 무관)
     long countByUser(User user);
 
+    /**
+     * 특정 사용자의 메모 중 삭제되지 않았고, 제목에 키워드가 포함된 메모들을 최신순으로 페이징 조회
+     * @param user 조회 대상 사용자
+     * @param keyword 검색 키워드 (제목 기준, 대소문자 무시)
+     * @param pageable 페이징 및 정렬 정보
+     * @return 키워드가 포함된 메모 페이지 객체
+     */
     Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(User user, String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- Added GET `/api/memos/search` endpoint for searching memos by title (case-insensitive).
- Integrated pagination using `Pageable` and custom response DTO.
- Added optional execution time logging (currently commented out).
- Applied in `MemoService` with `findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc`.
- Inactivated `FakeMemoDataLoader` running when initialized since its purpose is over for now.

## Modified Files
- MemoController
- MemoService
- MemoRepository
- FakerMemoDataLoader

## Notes
- Faker dummy data generator remains disabled by default (`enableFaker = false`)
- SQL logs are visible in console due to `spring.jpa.show-sql: true` (for debugging)
