### PR TITLE
feat: apply global exception handling and improve Swagger docs across Auth and Memo modules

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
@@ -9,9 +9,14 @@ import com.mymemo.backend.entity.User;
 import com.mymemo.backend.global.exception.CustomException;
 import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth API", description = "인증 관련 API 문서입니다.")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -37,10 +43,16 @@ public class AuthController {
      * @param requestDto 이메일, 비밀번호, 닉네임, 생일
      * @return 회원가입 성공 메시지
      */
+    @Operation(summary = "회원가입", description = "이메일, 비밀번호 등 정보를 바탕으로 회원가입을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값 오류"),
+            @ApiResponse(responseCode = "409", description = "이메일 중복 등 충돌")
+    })
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody @Valid SignupRequestDto requestDto) {
         authService.signup(requestDto);     // 회원 저장 로직 위임
-        return ResponseEntity.ok("회원가입 성공");
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공");
     }
 
     /**
@@ -48,6 +60,11 @@ public class AuthController {
      * @param request 이메일, 비밀번호
      * @return JWT accessToken 응답
      */
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 통해 로그인하고, AccessToken을 발급받습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값 오류 또는 이메일/비밀번호 불일치")
+    })
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto request) {
         User user;

--- a/backend/src/main/java/com/mymemo/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/filter/JwtAuthenticationFilter.java
@@ -59,7 +59,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 log.debug("SecurityContext에 인증 정보 등록 완료");
             } else {
-                log.warn("JWT 유효성 검사 실패");
+                log.warn("JWT 유효성 검사 실패 - 401 Unauthorized 응답 반환");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json; charset=UTF-8");
+                response.getWriter().write("{\"message\": \"토큰이 유효하지 않거나 만료되었습니다.\"}");
+                response.getWriter().flush();
+                return;
             }
         } else {
             log.debug("Authorization 헤더 없음 또는 Bearer 형식 불일치: {}", authHeader);

--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -1,9 +1,12 @@
 package com.mymemo.backend.global.exception;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 public enum ErrorCode {
 
+    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다. 관리자에게 문의하세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     MISSING_PASSWORD("비밀번호를 입력해주세요 .", HttpStatus.BAD_REQUEST),
     MISSING_NICKNAME("닉네임을 입력해주세요.", HttpStatus.BAD_REQUEST),
     MISSING_BIRTHDATE("생년월일을 입력해주세요.", HttpStatus.BAD_REQUEST),
@@ -14,16 +17,18 @@ public enum ErrorCode {
     INVALID_CREDENTIALS("이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_ACCESS("작성자는 필수입니다.", HttpStatus.UNAUTHORIZED),
     EMPTY_MEMO("아무 것도 작성하지 않으셨습니다.", HttpStatus.BAD_REQUEST),
-    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMO_NOT_FOUND("해당 메모를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ILLEGAL_ARGUMENT("잘못된 요청입니다.", HttpStatus.BAD_REQUEST)
     // 필요한 항목 계속 추가 가능
     ;
 
     private final String message;
-    private final HttpStatus status;
+    private final HttpStatus httpStatus;
 
-    ErrorCode(String message, HttpStatus status) {
+    ErrorCode(String message, HttpStatus httpStatus) {
         this.message = message;
-        this.status = status;
+        this.httpStatus = httpStatus;
     }
 
     public String getMessage() {
@@ -31,6 +36,6 @@ public enum ErrorCode {
     }
 
     public HttpStatus getStatus() {
-        return status;
+        return httpStatus;
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorResponse.java
@@ -12,8 +12,8 @@ public class ErrorResponse {
     private final int status;
     private final String message;
 
-    public ErrorResponse(int status, String message) {
-        this.status = status;
-        this.message = message;
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus().value();
+        this.message = errorCode.getMessage();
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/GlobalExceptionHandler.java
@@ -1,22 +1,34 @@
 package com.mymemo.backend.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        ErrorResponse response = new ErrorResponse(e.getStatus(), e.getMessage());
-        return ResponseEntity.status(e.getStatus()).body(response);
+        return ResponseEntity.status(e.getStatus()).body(new ErrorResponse(e.getErrorCode()));
     }
 
     // IllegalArgumentException 등 기본 예외도 잡을 수 있음
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
-        ErrorResponse response = new ErrorResponse(400, e.getMessage());
-        return ResponseEntity.badRequest().body(response);
+        return ResponseEntity
+                .status(ErrorCode.ILLEGAL_ARGUMENT.getHttpStatus())
+                .body(new ErrorResponse(ErrorCode.ILLEGAL_ARGUMENT));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected server error", e);
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.INTERNAL_SERVER_ERROR
+        );
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(response);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,23 +1,25 @@
 package com.mymemo.backend.memo.controller;
 
 import com.mymemo.backend.global.util.SecurityUtil;
-import com.mymemo.backend.memo.dto.MemoCreateRequestDto;
-import com.mymemo.backend.memo.dto.MemoCreateResponseDto;
-import com.mymemo.backend.memo.dto.MemoListResponseDto;
-import com.mymemo.backend.memo.dto.PageResponseDto;
+import com.mymemo.backend.memo.dto.*;
 import com.mymemo.backend.memo.service.MemoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Slf4j
+@Tag(name = "Memo API", description = "메모 관련 API 문서입니다.")
 @RestController
 @RequestMapping("/api/memos")
 @RequiredArgsConstructor
@@ -30,10 +32,16 @@ public class MemoController {
      * @param requestDto 제목, 카테고리, 내용
      * @return 메모 생성 성공 메시지
      */
+    @Operation(summary = "메모 생성", description = "새로운 메모를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "메모 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 유효성 실패"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요")
+    })
     @PostMapping
     public ResponseEntity<MemoCreateResponseDto> createMemo(@RequestBody MemoCreateRequestDto requestDto) {
         MemoCreateResponseDto responseDto = memoService.createMemo(requestDto);
-        return ResponseEntity.ok(responseDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     /**
@@ -42,16 +50,18 @@ public class MemoController {
      * @PageableDefault: 기본 페이지 크기와 정렬 기준 지정 (10개씩, 최신순)
      * @ParameterObject: Swagger UI에 pageable 파라미터 자동 반영
      */
+    @Operation(summary = "모든 메모 조회", description = "로그인한 사용자의 모든 메모 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요")
+    })
     @GetMapping
     public ResponseEntity<PageResponseDto<MemoListResponseDto>> getMemos(
             @ParameterObject @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
 //        long start = System.currentTimeMillis();
 
-        // 현재 로그인된 사용자의 이메일을 가져옴
-        String email = SecurityUtil.getCurrentUserEmail();
-
         // MemoService를 통해 페이징 처리된 메모 목록 응답을 받음
-        PageResponseDto<MemoListResponseDto> response = memoService.getMemos(email, pageable);
+        PageResponseDto<MemoListResponseDto> response = memoService.getMemos(pageable);
 
 //        long end = System.currentTimeMillis();
 //        log.info("[getAllMemos] 메모 조회 소요 시간: {} ms", (end - start));
@@ -66,6 +76,11 @@ public class MemoController {
      * @param pageable 페이징 및 정렬 정보
      * @return 페이징된 메모 응답
      */
+    @Operation(summary = "메모 키워드로 검색", description = "키워드를 통해 사용자의 메모 중 일치하는 항목을 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요")
+    })
     @GetMapping("/search")
     public ResponseEntity<PageResponseDto<MemoListResponseDto>> searchMemosByTitle(
             @RequestParam String keyword,
@@ -73,12 +88,35 @@ public class MemoController {
 
 //        long start = System.currentTimeMillis();
 
-        String email = SecurityUtil.getCurrentUserEmail();
-
-        PageResponseDto<MemoListResponseDto> response = memoService.getKeywordMemo(email, keyword, pageable);
+        PageResponseDto<MemoListResponseDto> response = memoService.getKeywordMemo(keyword, pageable);
 
 //        long end = System.currentTimeMillis();
 //        log.info("[searchMemosByTitle] 해당 키워드 포함한 메모 조회 소요 시간: {} ms", (end - start));
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 단일 메모 상세 조회 API
+     *
+     * 로그인한 사용자가 작성한 메모 중, 주어진 ID에 해당하는 메모의 상세 정보를 반환한다.
+     * - 삭제된 메모 또는 타인의 메모일 경우 예외가 발생한다.
+     *
+     * @param id 조회할 메모의 고유 ID (PathVariable)
+     * @return MemoDetailResponseDto 메모의 상세 정보 응답 객체
+     * @throws CustomException USER_NOT_FOUND: 로그인한 사용자가 존재하지 않을 경우
+     * @throws CustomException MEMO_NOT_FOUND: 해당 메모가 없거나 접근 권한이 없는 경우
+     */
+    @Operation(summary = "단일 메모 상세 조회", description = "로그인한 사용자의 메모 중, 주어진 ID에 해당하는 메모의 상세 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "메모를 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (토큰 없음 또는 만료)")
+    })
+    @Parameter(name = "id", description = "조회할 메모의 ID", required = true)
+    @GetMapping("/{id}")
+    public ResponseEntity<MemoDetailResponseDto> getMemoById(@PathVariable Long id) {
+        MemoDetailResponseDto response = memoService.getMemoDetail(id);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoDetailResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.mymemo.backend.memo.dto;
+
+import com.mymemo.backend.entity.Memo;
+import com.mymemo.backend.entity.enums.MemoCategory;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MemoDetailResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private MemoCategory memoCategory;
+    private boolean isPinned;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public MemoDetailResponseDto(Memo memo) {
+        this.id = memo.getId();
+        this.title = memo.getTitle();
+        this.content = memo.getContent();
+        this.memoCategory = memo.getMemoCategory();
+        this.isPinned = memo.isPinned();
+        this.createdAt = memo.getCreatedAt();
+        this.updatedAt = memo.getUpdatedAt();
+    }
+}

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
@@ -38,4 +39,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
      * @return 키워드가 포함된 메모 페이지 객체
      */
     Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(User user, String keyword, Pageable pageable);
+
+    Optional<Memo> findByIdAndUserAndIsDeletedFalse(Long id, User user);
 }


### PR DESCRIPTION
## Summary
- Applied global exception handling across multiple layers
  - Added fallback for unexpected exceptions in `GlobalExceptionHandler`
  - Standardized `ErrorCode` and `ErrorResponse` usage across modules
- Improved Swagger documentation for the Auth API (`@Tag`, `@ApiResponses`)
- Enhanced JWT authentication filter for clearer exception handling
- Refined memo feature behavior:
  - Improved exception handling in **individual memo detail retrieval**
  - Added handling for "memo not found" and "empty memo" cases
  - Updated `MemoDetailResponseDto` and repository logic accordingly

## Motivation
- Ensure consistent and centralized error responses using `CustomException` and `ErrorCode`
- Provide meaningful and user-friendly error feedback for memo detail API
- Improve API clarity and developer experience via Swagger UI documentation

## Modified Files
- `AuthController.java` — Added `@Tag`, refined response codes
- `JwtAuthenticationFilter.java` — Improved error flow
- `ErrorCode.java`, `ErrorResponse.java`, `GlobalExceptionHandler.java` — Standardized global exception structure
- `MemoController.java`, `MemoService.java` — Applied robust error handling in memo detail API
- `MemoDetailResponseDto.java` — Structured detail response for clarity
- `MemoRepository.java` — Updated for better query reliability