### PR TITLE
feat: implement memo deletion using soft delete

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -60,6 +60,10 @@ public class Memo {
         this.updatedAt = this.createdAt;
     }
 
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
     // 기존 생성자에 누락된 필드들 추가
     // -> visibility, isPinned, isDeleted, pinOrder 를 인자로 받아 초기화
     public Memo(User user, String title, String content, MemoCategory memoCategory, Visibility visibility, boolean isPinned, boolean isDeleted, int pinOrder) {

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -147,5 +148,28 @@ public class MemoController {
         MemoUpdateResponseDto response = memoService.updateMemo(id, requestDto);
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * [DELETE] /api/memos/{id}
+     * 메모를 삭제하는 API (soft delete 방식)
+     *
+     * 로그인한 사용자가 작성한 메모를 삭제한다.
+     * 실제로 DB에서 삭제되지는 않고, deleted 플래그가 true로 설정된다.
+     *
+     * @param memoId 삭제할 메모의 ID (PathVariable)
+     * @return 204 No Content
+     */
+    @Operation(summary = "메모 삭제", description = "ID에 해당하는 메모를 삭제합니다. (soft delete 방식)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "메모를 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (토큰 없음 또는 만료)")
+    })
+    @Parameter(name = "id", description = "삭제할 메모의 ID", required = true)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMemo(@PathVariable("id") Long memoId) {   // URL 경로에서 id 값을 추출하여 memoId 파라미터로 전달
+        memoService.deleteMemo(memoId);     // 서비스 로직 호출
+        return ResponseEntity.noContent().build();      // HTTP 상태 코드 204 No Content 반환 => 성공했지만 본문(body)은 없다는 뜻 (일반적으로 삭제 시 적절한 응답)
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -125,7 +125,7 @@ public class MemoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 메모 조회 (작성자 본인의 메모인지 확인)
-        Memo memo = memoRepository.findByIdAndUser(memoId, user)
+        Memo memo = memoRepository.findByIdAndUserAndIsDeletedFalse(memoId, user)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMO_NOT_FOUND));
 
         // 3. 메모 수정
@@ -139,5 +139,22 @@ public class MemoService {
 
         // 4. 응답 반환
         return new MemoUpdateResponseDto(memo);
+    }
+
+    @Transactional
+    public void deleteMemo(Long memoId) {
+        // 1. 현재 로그인한 사용자 이메일 확인
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        // 2. 사용자 정보 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 3. 삭제되지 않은 메모인지 확인하며 조회
+        Memo memo = memoRepository.findByIdAndUserAndIsDeletedFalse(memoId, user)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_NOT_FOUND));
+
+        // 4. soft delete 처리
+        memo.softDelete();
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -41,6 +41,4 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(User user, String keyword, Pageable pageable);
 
     Optional<Memo> findByIdAndUserAndIsDeletedFalse(Long id, User user);
-
-    Optional<Memo> findByIdAndUser(Long id, User user);
 }


### PR DESCRIPTION
### Description
This PR implements the memo deletion feature using a soft delete strategy.

### Key Changes
- Added `isDeleted` field and `softDelete()` method to the `Memo` entity
- Updated repository methods to exclude deleted memos (`isDeleted = false`)
- Implemented `deleteMemo()` logic in `MemoService`
- Added DELETE endpoint to `MemoController` (`/api/memos/{id}`)
- Applied Swagger annotations for API documentation

### Testing
- Verified that deleted memos do not appear in list, detail, or update APIs
- Confirmed DELETE request via Swagger UI returns 204 No Content