### PR TITLE
feat: apply pinned memo sorting to search results

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -64,6 +64,10 @@ public class Memo {
         this.isDeleted = true;
     }
 
+    public void updatePinOrder(int pinOrder) {
+        this.pinOrder = pinOrder;
+    }
+
     // 기존 생성자에 누락된 필드들 추가
     // -> visibility, isPinned, isDeleted, pinOrder 를 인자로 받아 초기화
     public Memo(User user, String title, String content, MemoCategory memoCategory, Visibility visibility, boolean isPinned, boolean isDeleted, int pinOrder) {

--- a/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/service/MemoService.java
@@ -68,7 +68,7 @@ public class MemoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 삭제되지 않은 메모들을 최신순으로 페이징 조회
-        Page<Memo> memoPage = memoRepository.findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(user, pageable);
+        Page<Memo> memoPage = memoRepository.findByUserAndIsDeletedFalseOrderByIsPinnedDescPinOrderAscUpdatedAtDesc(user, pageable);
 
         return toPageResponse(memoPage);
     }
@@ -86,7 +86,7 @@ public class MemoService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Page<Memo> memoPage = memoRepository.findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(user, keyword, pageable);
+        Page<Memo> memoPage = memoRepository.findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByIsPinnedDescPinOrderAscUpdatedAtDesc(user, keyword, pageable);
 
         return toPageResponse(memoPage);
     }

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -26,7 +26,7 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     List<Memo> findAllByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user);
 
     // 해당 사용자의 메모를 페이징 처리하여 최신순으로 조회 (삭제되지 않은 메모만 포함)
-    Page<Memo> findByUserAndIsDeletedFalseOrderByUpdatedAtDesc(User user, Pageable pageable);
+    Page<Memo> findByUserAndIsDeletedFalseOrderByIsPinnedDescPinOrderAscUpdatedAtDesc(User user, Pageable pageable);
 
     // 해당 사용자가 작성한 전체 메모 개수를 반환 (삭제 여부와 무관)
     long countByUser(User user);
@@ -38,7 +38,7 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
      * @param pageable 페이징 및 정렬 정보
      * @return 키워드가 포함된 메모 페이지 객체
      */
-    Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByUpdatedAtDesc(User user, String keyword, Pageable pageable);
+    Page<Memo> findByUserAndTitleContainingIgnoreCaseAndIsDeletedFalseOrderByIsPinnedDescPinOrderAscUpdatedAtDesc(User user, String keyword, Pageable pageable);
 
     Optional<Memo> findByIdAndUserAndIsDeletedFalse(Long id, User user);
 }


### PR DESCRIPTION
### Description
This PR ensures that pinned memos appear at the top of the search results, consistent with the general memo list.

### Changes
- Updated `MemoRepository` search query method to apply sorting:
  - `isPinned DESC`
  - `pinOrder ASC`
  - `updatedAt DESC`
- Now both general list and search results prioritize pinned memos

### Test
- Verified via Swagger UI that pinned memos show up at the top when searching by title
- Pagination and keyword filtering work as expected