### PR TITLE
feat: implement token reissue feature using Redis

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
@@ -1,8 +1,6 @@
 package com.mymemo.backend.auth.controller;
 
-import com.mymemo.backend.auth.dto.LoginRequestDto;
-import com.mymemo.backend.auth.dto.LoginResponseDto;
-import com.mymemo.backend.auth.dto.SignupRequestDto;
+import com.mymemo.backend.auth.dto.*;
 import com.mymemo.backend.auth.service.AuthService;
 import com.mymemo.backend.auth.util.JwtUtil;
 import com.mymemo.backend.entity.User;
@@ -92,5 +90,21 @@ public class AuthController {
 
         // accessToken 담아 응답
         return ResponseEntity.ok(new LoginResponseDto(accessToken));
+    }
+
+    /**
+     * Access Token 재발급 API
+     * @param requestDto 사용자 이메일과 Refresh Token
+     * @return 새로운 Access Token 및 Refresh Token
+     */
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 검증해 새로운 Access Token과 Refresh Token을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "Refresh Token 유효성 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
+    })
+    @PostMapping("/reissue")
+    public TokenResponseDto reissue(@RequestBody TokenReissueRequestDto requestDto) {
+        return authService.reissue(requestDto);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/auth/dto/TokenReissueRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/dto/TokenReissueRequestDto.java
@@ -1,0 +1,14 @@
+package com.mymemo.backend.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequestDto {
+
+    @Schema(description = "사용자 이메일", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "요청에 포함된 Refresh Token", example = "aaa.bbb.ccc")
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/mymemo/backend/auth/dto/TokenResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/dto/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.mymemo.backend.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
@@ -1,13 +1,19 @@
 package com.mymemo.backend.auth.service;
 
 import com.mymemo.backend.auth.dto.SignupRequestDto;
+import com.mymemo.backend.auth.dto.TokenReissueRequestDto;
+import com.mymemo.backend.auth.dto.TokenResponseDto;
+import com.mymemo.backend.auth.util.JwtUtil;
 import com.mymemo.backend.entity.User;
 import com.mymemo.backend.global.exception.CustomException;
 import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +21,8 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final StringRedisTemplate redisTemplate;
 
     public void signup(SignupRequestDto dto) {
         // 1. 이메일 중복 체크
@@ -39,5 +47,45 @@ public class AuthService {
         );
 
         userRepository.save(user);
+    }
+
+    public TokenResponseDto reissue(TokenReissueRequestDto dto) {
+        String email = dto.getEmail();
+        String requestRefreshToken = dto.getRefreshToken();
+
+        // 1. 이메일로 사용자 존재 여부 확인
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_FOUND));
+
+        // 2. Redis에서 해당 이메일로 저장된 Refresh Token 조회
+        String storedToken = redisTemplate.opsForValue().get("RT:" + email);
+        if (storedToken == null) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // 3. 요청된 Refresh Token이 저장된 토큰과 일치하는지 확인
+        if (!storedToken.equals(requestRefreshToken)) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 4. 요청된 Refresh Token의 유효성 검증 (만료 여부, 시그니처 등)
+        if (!jwtUtil.isTokenValid(requestRefreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 5. 유효한 경우 새로운 Access Token과 Refresh Token 발급
+        String newAccessToken = jwtUtil.createAccessToken(email);
+        String newRefreshToken = jwtUtil.createRefreshToken(email);
+
+        // 6. Redis에 새로운 Refresh Token을 저장 (기존 것 대체), 유효기간 설정
+        redisTemplate.opsForValue().set(
+                "RT:" + email,
+                newRefreshToken,
+                jwtUtil.getRefreshTokenValidityInMs(),
+                TimeUnit.MILLISECONDS
+        );
+
+        // 7. 새로운 토큰 쌍을 응답으로 반환
+        return new TokenResponseDto(newAccessToken, newRefreshToken);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
     EMPTY_MEMO("아무 것도 작성하지 않으셨습니다.", HttpStatus.BAD_REQUEST),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     MEMO_NOT_FOUND("해당 메모를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ILLEGAL_ARGUMENT("잘못된 요청입니다.", HttpStatus.BAD_REQUEST)
+    ILLEGAL_ARGUMENT("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    REFRESH_TOKEN_NOT_FOUND("저장된 Refresh Token이 없습니다.", HttpStatus.UNAUTHORIZED),
+    REFRESH_TOKEN_MISMATCH("요청한 Refresh Token이 저장된 토큰과 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("Refresh Token이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED)
     // 필요한 항목 계속 추가 가능
     ;
 


### PR DESCRIPTION
### Changes
- Added `TokenReissueRequestDto` and `TokenResponseDto` for reissue API
- Implemented `/api/auth/reissue` endpoint in `AuthController`
- Extended `AuthService` with `reissue()` method
  - Validates Refresh Token from Redis
  - Compares with client token and issues new access/refresh tokens
- Updated `ErrorCode` enum with relevant refresh token errors
- Registered `StringRedisTemplate` for token storage

### Notes
- Redis TTL is set to the refresh token validity period
- `JwtUtil.isTokenValid()` is used for token integrity and expiration check