### PR TITLE
feat: add logout API to remove refresh token from Redis

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/controller/AuthController.java
@@ -83,4 +83,20 @@ public class AuthController {
     public TokenResponseDto reissue(@RequestBody TokenReissueRequestDto requestDto) {
         return authService.reissue(requestDto);
     }
+
+    /**
+     * 로그아웃 API
+     * @param requestDto 사용자 이메일
+     * @return 로그아웃 성공 메시지
+     */
+    @Operation(summary = "로그아웃", description = "Redis에 저장된 Refresh Token을 삭제하여 로그아웃 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "404", description = "저장된 Refresh Token 없음")
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestBody TokenLogoutRequestDto requestDto) {
+        authService.logout(requestDto.getEmail());
+        return ResponseEntity.ok("로그아웃 성공");
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/auth/dto/TokenLogoutRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/dto/TokenLogoutRequestDto.java
@@ -1,0 +1,10 @@
+package com.mymemo.backend.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class TokenLogoutRequestDto {
+    @Schema(description = "로그아웃 대상 사용자 이메일", example = "user@example.com")
+    private String email;
+}

--- a/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/service/AuthService.java
@@ -122,4 +122,14 @@ public class AuthService {
         // Access Token + Refresh Token 응답 객체로 반환
         return new TokenResponseDto(accessToken, refreshToken);
     }
+
+    public void logout(String email) {
+        // Redis에서 Refresh Token 제거
+        Boolean result = redisTemplate.delete("RT:" + email);
+
+        if (result == null || !result) {
+            // Redis에 해당 키가 없거나 삭제 실패
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+    }
 }


### PR DESCRIPTION
### Summary
- Added `/api/auth/logout` endpoint in `AuthController`
- Implemented `logout(String email)` method in `AuthService`
- On logout, removes the refresh token from Redis for the given user
- Throws `REFRESH_TOKEN_NOT_FOUND` error if no refresh token exists for the user