### PR TITLE
feat: Add Access Token blacklist handling on logout using Redis

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/auth/util/JwtUtil.java
+++ b/backend/src/main/java/com/mymemo/backend/auth/util/JwtUtil.java
@@ -93,4 +93,19 @@ public class JwtUtil {
     public long getRefreshTokenValidityInMs() {
         return refreshTokenValidityInMs;    // application.yml에서 설정한 값 그대로 반환
     }
+
+    // Access Token 남은 유효시간 반환 메서드
+    public long getTokenRemainingTime(String token) {
+        // 1. JWT 파서 객체를 생성하고 서명 키를 설정함
+        //    -> 이 키를 이용해 토큰의 서명 유효성을 검증하면서 파싱 수행
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)                    // JWT 검증을 위한 서명 키 설정
+                .build()
+                .parseClaimsJws(token)                 // 토큰 파싱 및 서명 검증 (Claims 추출)
+                .getBody()
+                .getExpiration();                      // Claims에서 만료 시간(Date) 추출
+
+        // 2. 만료 시각과 현재 시간의 차이를 계산 -> 남은 시간 (ms)
+        return expiration.getTime() - System.currentTimeMillis();
+    }
 }

--- a/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final StringRedisTemplate redisTemplate;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -31,7 +33,7 @@ public class SecurityConfig {
     // JwtAuthenticationFilter는 공통이므로 따로 @Bean 등록
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil);
+        return new JwtAuthenticationFilter(jwtUtil, redisTemplate);
     }
 
     @Bean
@@ -67,7 +69,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form.disable())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     ILLEGAL_ARGUMENT("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
     REFRESH_TOKEN_NOT_FOUND("저장된 Refresh Token이 없습니다.", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_MISMATCH("요청한 Refresh Token이 저장된 토큰과 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_REFRESH_TOKEN("Refresh Token이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED)
+    INVALID_REFRESH_TOKEN("Refresh Token이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_BLACKLISTED("로그아웃된 토큰입니다.", HttpStatus.UNAUTHORIZED)
     // 필요한 항목 계속 추가 가능
     ;
 

--- a/backend/src/main/java/com/mymemo/backend/global/util/SecurityUtil.java
+++ b/backend/src/main/java/com/mymemo/backend/global/util/SecurityUtil.java
@@ -1,6 +1,10 @@
 package com.mymemo.backend.global.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * 인증 정보에서 현재 로그인한 사용자의 이메일(username)을 반환하는 유틸 클래스.
@@ -17,5 +21,34 @@ public class SecurityUtil {
      */
     public static String getCurrentUserEmail() {
         return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+
+    /**
+     * 현재 HTTP 요청의 Authorization 헤더에서 Access Token 값을 추출한다.
+     *
+     * Authorization 헤더는 일반적으로 다음과 같은 형태로 전달된다:
+     *
+     *     Authorization: Bearer {AccessToken}
+     *
+     * 이 메서드는 해당 헤더에서 "Bearer " 접두사를 제거한 실제 토큰 문자열만 반환한다.
+     *
+     * @return 요청 헤더에 포함된 Access Token (접두사 제거된 형태), 없으면 null
+     */
+    public static String getCurrentToken() {
+        // 현재 요청(Request)의 HttpServletRequest 객체를 가져옴
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+
+        // Authorization 헤더 값 추출 (예: "Bearer ~~~")
+        String bearerToken = request.getHeader("Authorization");
+
+        // bearerToken이 비어있지 않고 "Bearer "로 시작하는지 확인
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            // "Bearer " 이후의 실제 토큰 값만 잘라서 반환
+            return bearerToken.substring(7);
+        }
+
+        // Authorization 헤더가 없거나 형식이 잘못된 경우 null 반환
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for blacklisting Access Tokens using Redis when a user logs out.

## Changes
- On logout, the Access Token is stored in Redis with its remaining TTL
- JwtAuthenticationFilter checks Redis and blocks blacklisted tokens
- Injected `StringRedisTemplate` into the filter and SecurityConfig

## Result
- Logged-out tokens cannot be used again
- Returns 401 with a clear message if a blacklisted token is used