### PR TITLE
feat: apply memo visibility control and restrict access to private memos

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymemo/backend/global/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND("저장된 Refresh Token이 없습니다.", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_MISMATCH("요청한 Refresh Token이 저장된 토큰과 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN("Refresh Token이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    TOKEN_BLACKLISTED("로그아웃된 토큰입니다.", HttpStatus.UNAUTHORIZED)
+    TOKEN_BLACKLISTED("로그아웃된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    MEMO_PRIVATE_ACCESS_DENIED("비공개 메모는 소유자만 조회할 수 있습니다.", HttpStatus.FORBIDDEN)
     // 필요한 항목 계속 추가 가능
     ;
 

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -46,4 +46,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     @Query("SELECT COALESCE(MIN(m.pinOrder), 0) FROM Memo AS m WHERE m.user = :user AND m.isPinned = true AND m.isDeleted = false")
     int findMinPinOrderByUser(@Param("user") User user);
+
+    Optional<Memo> findByIdAndIsDeletedFalse(Long id);
 }


### PR DESCRIPTION
### What was changed
- Added `Visibility` (PUBLIC, PRIVATE) to memos
- Changed `getMemoDetail()` so:
  - Memo owner can always view
  - Others can only view if the memo is PUBLIC
- Added new error for trying to access private memo without permission
- Updated comments and error codes

### Next step
- Switch memo ID from Long to UUID