### PR TITLE
feat: set default visibility to PRIVATE when creating a memo

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
@@ -21,8 +21,8 @@ public class MemoCreateRequestDto {
             example = "ETC")
     private MemoCategory memoCategory;
 
-    @Schema(description = "공개 여부", defaultValue = "PUBLIC", hidden = true)
-    private Visibility visibility;
+    @Schema(description = "공개 여부", defaultValue = "PRIVATE", hidden = true)
+    private Visibility visibility = Visibility.PRIVATE;
 
     @Schema(description = "상단 고정 여부", defaultValue = "false", example = "false", hidden = true)    // Swagger 예시가 isPinned 대신 pinned 로 출력되도록 매핑 처리
     @JsonProperty("pinned")     // JSON 프로퍼티 이름을 pinned 로 설정해 직관성 확보
@@ -71,7 +71,8 @@ public class MemoCreateRequestDto {
     // SRP(단일 책임 원칙) 준수 및 서비스 코드 간결화
     // 엔터티 생성 메서드. DTO -> Entity 변환 책임 (중심 로직)
     public Memo toEntity(User user) {
+        Visibility resolvedVisibility = (this.visibility != null) ? this.visibility : Visibility.PRIVATE;
 
-        return new Memo(user, title, content, memoCategory, visibility, isPinned, false, 0);
+        return new Memo(user, title, content, memoCategory, resolvedVisibility, isPinned, false, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Changed the default visibility of a memo to PRIVATE.

## Details
- Users now create memos as PRIVATE by default.
- Prevents unintended exposure of personal content.