### PR TITLE
feat: add UUID-based public memo retrieval

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/entity/Memo.java
+++ b/backend/src/main/java/com/mymemo/backend/entity/Memo.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -52,6 +53,9 @@ public class Memo {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(unique = true, nullable = false, updatable = false)
+    private String uuid;
+
     protected Memo() {}     // protected를 하여 불필요한 객체 생성 가능성 방지
 
     @PrePersist
@@ -70,7 +74,7 @@ public class Memo {
 
     // 기존 생성자에 누락된 필드들 추가
     // -> visibility, isPinned, isDeleted, pinOrder 를 인자로 받아 초기화
-    public Memo(User user, String title, String content, MemoCategory memoCategory, Visibility visibility, boolean isPinned, boolean isDeleted, int pinOrder) {
+    public Memo(User user, String title, String content, MemoCategory memoCategory, Visibility visibility, boolean isPinned, boolean isDeleted, int pinOrder, String uuid) {
         if (user == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -102,6 +106,7 @@ public class Memo {
         this.isPinned = isPinned;
         this.isDeleted = isDeleted;
         this.pinOrder = pinOrder;
+        this.uuid = UUID.randomUUID().toString();
     }
 
     // update 를 아래에서 조건부로 처리하고 있기 때문에 주석 처리

--- a/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/controller/MemoController.java
@@ -1,5 +1,9 @@
 package com.mymemo.backend.memo.controller;
 
+import com.mymemo.backend.entity.Memo;
+import com.mymemo.backend.entity.enums.Visibility;
+import com.mymemo.backend.global.exception.CustomException;
+import com.mymemo.backend.global.exception.ErrorCode;
 import com.mymemo.backend.global.util.SecurityUtil;
 import com.mymemo.backend.memo.dto.*;
 import com.mymemo.backend.memo.service.MemoService;
@@ -171,5 +175,27 @@ public class MemoController {
     public ResponseEntity<Void> deleteMemo(@PathVariable("id") Long memoId) {   // URL 경로에서 id 값을 추출하여 memoId 파라미터로 전달
         memoService.deleteMemo(memoId);     // 서비스 로직 호출
         return ResponseEntity.noContent().build();      // HTTP 상태 코드 204 No Content 반환 => 성공했지만 본문(body)은 없다는 뜻 (일반적으로 삭제 시 적절한 응답)
+    }
+
+    /**
+     * [GET] /api/memos/public/{uuid}
+     * UUID 기반으로 공개 메모 조회 (비회원 가능)
+     * <p>
+     * 공개 상태인 메모만 조회 가능하며, 비공개 메모일 경우 접근이 거부된다.
+     *
+     * @param uuid 조회할 메모의 UUID
+     * @return MemoDetailResponseDto 메모의 상세 정보
+     */
+    @Operation(summary = "UUID 기반 공개 메모 조회", description = "공개 상태인 메모를 UUID로 조회합니다. 비회원도 접근 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "비공개 메모 접근 시도"),
+            @ApiResponse(responseCode = "404", description = "메모를 찾을 수 없음")
+    })
+    @Parameter(name = "uuid", description = "조회할 메모의 UUID", required = true)
+    @GetMapping("/public/{uuid}")
+    public ResponseEntity<MemoDetailResponseDto> getMemoByUuid(@PathVariable String uuid) {
+        MemoDetailResponseDto response = memoService.getMemoDetailByUuid(uuid);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
+++ b/backend/src/main/java/com/mymemo/backend/repository/MemoRepository.java
@@ -48,4 +48,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     int findMinPinOrderByUser(@Param("user") User user);
 
     Optional<Memo> findByIdAndIsDeletedFalse(Long id);
+
+    Optional<Memo> findByUuidAndIsDeletedFalse(String uuid);
 }


### PR DESCRIPTION
### Changes
- Added API to get public memo by UUID (`/api/memos/public/{uuid}`)
- Added read-only transaction to the service method
- Handled private memo access with proper exception
- Improved code clarity and consistency

### Why
To allow non-logged-in users to read public memos using UUID without exposing user info or internal ID.