### PR TITLE
feat: Add UUID support for public memo sharing and adjust response DTOs

### DIFF
--- a/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mymemo/backend/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",     // 로그인, 회원가입 등은 인증 없이 허용
+                                "/api/memos/public/**",     // 비회원도 접근 가능하도록 허용
                                 "/v3/api-docs/**",  // Swagger
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"
@@ -65,7 +66,10 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/api/memos/public/**"      // 공개 메모 조회 허용
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form.disable())

--- a/backend/src/main/java/com/mymemo/backend/init/FakeMemoDataLoader.java
+++ b/backend/src/main/java/com/mymemo/backend/init/FakeMemoDataLoader.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Locale;
 import java.util.Random;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -57,7 +58,7 @@ public class FakeMemoDataLoader implements CommandLineRunner {
             boolean isPinned = random.nextBoolean();
             Visibility visibility = random.nextBoolean() ? Visibility.PUBLIC : Visibility.PRIVATE;
 
-            Memo memo = new Memo(user, title, content, category, visibility, isPinned, false, 0);
+            Memo memo = new Memo(user, title, content, category, visibility, isPinned, false, 0, UUID.randomUUID().toString());
             memoRepository.save(memo);
 
             if (i % 1000 == 0) {

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateRequestDto.java
@@ -7,6 +7,8 @@ import com.mymemo.backend.entity.enums.MemoCategory;
 import com.mymemo.backend.entity.enums.Visibility;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.UUID;
+
 public class MemoCreateRequestDto {
 
     @Schema(description = "메모 제목")
@@ -73,6 +75,6 @@ public class MemoCreateRequestDto {
     public Memo toEntity(User user) {
         Visibility resolvedVisibility = (this.visibility != null) ? this.visibility : Visibility.PRIVATE;
 
-        return new Memo(user, title, content, memoCategory, resolvedVisibility, isPinned, false, 0);
+        return new Memo(user, title, content, memoCategory, resolvedVisibility, isPinned, false, 0, UUID.randomUUID().toString());
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoCreateResponseDto.java
@@ -2,6 +2,7 @@ package com.mymemo.backend.memo.dto;
 
 import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.enums.MemoCategory;
+import com.mymemo.backend.entity.enums.Visibility;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,8 @@ public class MemoCreateResponseDto {
     private String title;
     private String content;
     private MemoCategory memoCategory;
+    private Visibility visibility;
+    private String uuid;
     private LocalDateTime createdAt;
 
     public MemoCreateResponseDto(Memo memo) {
@@ -20,6 +23,8 @@ public class MemoCreateResponseDto {
         this.title = memo.getTitle();
         this.content = memo.getContent();
         this.memoCategory = memo.getMemoCategory();
+        this.visibility = memo.getVisibility();
+        this.uuid = memo.getUuid();
         this.createdAt = memo.getCreatedAt();
     }
 }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoDetailResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.mymemo.backend.memo.dto;
 
 import com.mymemo.backend.entity.Memo;
 import com.mymemo.backend.entity.enums.MemoCategory;
+import com.mymemo.backend.entity.enums.Visibility;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,7 +13,9 @@ public class MemoDetailResponseDto {
     private String title;
     private String content;
     private MemoCategory memoCategory;
+    private Visibility visibility;
     private boolean isPinned;
+    private String uuid;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -21,7 +24,9 @@ public class MemoDetailResponseDto {
         this.title = memo.getTitle();
         this.content = memo.getContent();
         this.memoCategory = memo.getMemoCategory();
+        this.visibility = memo.getVisibility();
         this.isPinned = memo.isPinned();
+        this.uuid = memo.getUuid();
         this.createdAt = memo.getCreatedAt();
         this.updatedAt = memo.getUpdatedAt();
     }

--- a/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
+++ b/backend/src/main/java/com/mymemo/backend/memo/dto/MemoListResponseDto.java
@@ -16,6 +16,7 @@ public class MemoListResponseDto {
     private MemoCategory memoCategory;
     private Visibility visibility;
     private boolean isPinned;
+    private String uuid;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String preview;     // 메모 전체 조회할 때 100자까지만 미리보기
@@ -27,6 +28,7 @@ public class MemoListResponseDto {
         this.memoCategory = memo.getMemoCategory();
         this.visibility = memo.getVisibility();
         this.isPinned = memo.isPinned();
+        this.uuid = memo.getUuid();
         this.createdAt = memo.getCreatedAt();
         this.updatedAt = memo.getUpdatedAt();
         this.preview = generatePreview(content);


### PR DESCRIPTION
### Changes
- Added `uuid` field to `Memo` entity for public sharing
- Modified response DTOs to include `uuid` and `visibility`
- Allowed unauthenticated users to access public memos by UUID
- Updated SecurityConfig to permit `/api/memos/public/**` in both dev and prod profiles
- Verified correct response format from Swagger

### Notes
- `uuid` is assigned on creation regardless of visibility
- `id` is still included in responses but can be ignored on the frontend